### PR TITLE
Use Date.now when possible

### DIFF
--- a/src/mina.js
+++ b/src/mina.js
@@ -43,7 +43,7 @@ var mina = (function (eve) {
             return a + dif * (bb - b);
         };
     },
-    timer = function () {
+    timer = Date.now || function () {
         return +new Date;
     },
     sta = function (val) {


### PR DESCRIPTION
Modern browsers provides ES5 `Date.now()` that does exactly the same as `+new Date()`, but doesn't create a `Date` object so it shouldn't be collected by GC.
