### PR TITLE
@ fix bug for transform="translate(x)"

### DIFF
--- a/src/svg.js
+++ b/src/svg.js
@@ -1163,7 +1163,9 @@ function transform2matrix(tstr, bbox) {
                 x2,
                 y2,
                 bb;
-            if (command == "t" && tlen == 3) {
+            if (command == "t" && tlen == 2){
+                m.translate(t[1], 0);
+            } else if (command == "t" && tlen == 3) {
                 if (absolute) {
                     x1 = inver.x(0, 0);
                     y1 = inver.y(0, 0);


### PR DESCRIPTION
if element has transform="translate(5)", snap.svg ignore that but it works and it's possible on transform attribute.
