### PR TITLE
Patch bbox

### DIFF
--- a/src/svg.js
+++ b/src/svg.js
@@ -1541,7 +1541,7 @@ function arrayFirstValue(arr) {
             _.bboxwt = Snap.path.get[el.type] ? Snap.path.getBBox(el.realPath = Snap.path.get[el.type](el)) : Snap._.box(el.node.getBBox());
             return Snap._.box(_.bboxwt);
         } else {
-            if(typeof el.realPath == 'undefined')
+            if(typeof el.realPath == 'undefined' || el.type != 'g')
                 el.realPath = (Snap.path.get[el.type] || Snap.path.get.deflt)(el);
 
             _.bbox = Snap.path.getBBox(Snap.path.map(el.realPath, el.matrix));


### PR DESCRIPTION
If i get bbox for group with specific scaling matrix, the calculate realPath is false (the origin is set to 0,0) while nor;ally, the realpath does not change
