### PR TITLE
Element.drag is broken because identifier, dx, dy a

### DIFF
--- a/src/mouse.js
+++ b/src/mouse.js
@@ -431,12 +431,13 @@ Snap.plugin(function (Snap, Element, Paper, glob) {
             });
         }
         function start(e) {
+            var ev = (supportsTouch && e.touches ? e.touches[0] : e); // standard mous event or first touch
             (e.originalEvent || e).preventDefault();
             var scrollY = getScroll("y"),
                 scrollX = getScroll("x");
-            this._drag.x = e.clientX + scrollX;
-            this._drag.y = e.clientY + scrollY;
-            this._drag.id = e.identifier;
+            this._drag.x = ev.clientX + scrollX;
+            this._drag.y = ev.clientY + scrollY;
+            this._drag.id = ev.identifier;
             !drag.length && Snap.mousemove(dragMove).mouseup(dragUp);
             drag.push({el: this, move_scope: move_scope, start_scope: start_scope, end_scope: end_scope});
             onstart && eve.on("snap.drag.start." + this.id, onstart);


### PR DESCRIPTION
On touch devices this._drag.x, this._drag.y, this._drag.id used to be undefined this caused dx and dy in the Element.drag handlers to be NaN
