### PR TITLE
fix null error if element defs not exist.

### DIFF
--- a/src/svg.js
+++ b/src/svg.js
@@ -1279,7 +1279,8 @@ function getSomeDefs(el) {
             (el.node.parentNode && wrap(el.node.parentNode)) ||
             Snap.select("svg") ||
             Snap(0, 0),
-        defs = p.select("defs").node;
+        pdefs = p.select("defs"),
+        defs  = pdefs == null ? false : pdefs.node;
     if (!defs) {
         defs = make("defs", p.node).node;
     }


### PR DESCRIPTION
If svg <defs> element does not exist, snap.svg throw null error and crash all javascript execution.

In this case, `p.select("defs")` return null but, in your code, you use `p.select("defs").node` directly without test if `p.select("defs")` return null.
