### PR TITLE
enabling fluent-interface for `group.add`

### DIFF
--- a/src/svg.js
+++ b/src/svg.js
@@ -1419,6 +1419,7 @@ function add2group(list) {
     for (i = 0; i < children.length; i++) {
         this[j++] = wrap(children[i]);
     }
+    return this;
 }
 function Element(el) {
     if (el.snap in hub) {


### PR DESCRIPTION
I stumbled over this one today as I wanted to add some elements to a group and afterwards animate this group by chaining the associated methods.
