### PR TITLE
Update index.html to remove misleading use of 'selectAll'

### DIFF
--- a/demos/tutorial/index.html
+++ b/demos/tutorial/index.html
@@ -227,7 +227,7 @@ Snap.load("mascot.svg", function (f) {
 s.text(200, 100, "Snap.svg");</li>
 <li>// Provide an array of strings (or arrays), to generate tspans
 var t = s.text(200, 120, ["Snap", ".", "svg"]);
-t.selectAll("tspan:nth-child(3)").attr({
+t.select("tspan:nth-child(3)").attr({
     fill: "#900",
     "font-size": "20px"
 });</li>


### PR DESCRIPTION
Original line uses a selector that can select only one element/object (the 3rd tspan child element of 't'). The 'select' method seems more appropriate than 'selectAll' in this scenario for this reason.
