### PR TITLE
Fix problem with regexp in getattr.filter

### DIFF
--- a/src/filter.js
+++ b/src/filter.js
@@ -14,7 +14,7 @@
 Snap.plugin(function (Snap, Element, Paper, glob) {
     var elproto = Element.prototype,
         pproto = Paper.prototype,
-        rgurl = /^\s*url\((.+)\)/,
+        rgurl = /^\s*url\(['"]?(^[\)'"]+)\)/,
         Str = String,
         $ = Snap._.$;
     Snap.filter = {};


### PR DESCRIPTION
Current regexp causes exception: `"Uncaught SyntaxError: Failed to execute query: ''#Shr6qrjpz1'' is not a valid selector."`. It happening because `"url('#Shr6qrjpz1')".match(/^\s*url\((.+)\)/)[1]` returns `"'#Shr6qrjpz1'"` instead of `"#Shr6qrjpz1"`.
