### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "Snap.svg",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "homepage": "http://snapsvg.io",
   "authors": [
     "Dmitry Baranovskiy <dmitry@baranovskiy.com>"


### PR DESCRIPTION
Installing snap I get the error:

```
$ bower install snap.svg --save
bower snap.svg#*            not-cached git://github.com/adobe-webplatform/Snap.svg.git#*
bower snap.svg#*               resolve git://github.com/adobe-webplatform/Snap.svg.git#*
bower snap.svg#*              download https://github.com/adobe-webplatform/Snap.svg/archive/v0.2.0.tar.gz
bower snap.svg#*               extract archive.tar.gz
bower snap.svg#*              mismatch Version declared in the json (0.1.1) is different than the resolved one (0.2.0)
bower snap.svg#*              resolved git://github.com/adobe-webplatform/Snap.svg.git#0.2.0
bower snap.svg#~0.2.0          install snap.svg#0.2.0
```
