### PR TITLE
Element.transform().toString() fix attempt

### DIFF
--- a/src/svg.js
+++ b/src/svg.js
@@ -1359,7 +1359,7 @@ function Element(el) {
                 i,
                 localString = local.toTransformString(),
                 string = Str(local) == Str(this.matrix) ?
-                            _.transform : localString;
+                            Str(_.transform) : localString;
             while (papa.type != "svg" && (papa = papa.parent())) {
                 ms.push(extractTransform(papa));
             }


### PR DESCRIPTION
Sometimes calling .transform().toString() returns an object, instead of a string.

elproto._.transform gets assigned to the toString() property of the transform() return value,
but this value is an object.

Sample case:
http://jsfiddle.net/bitblitter/hUWT7/3/
