### PR TITLE
Fixing npm install by updating main property

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "snapsvg",
     "version": "0.3.0",
     "description": "JavaScript Vector Library",
-    "main": "Gruntfile.js",
+    "main": "./dist/snap.svg.js",
     "repository": {
         "type": "git",
         "url": "git@github.com:adobe-webplatform/Snap.svg.git"


### PR DESCRIPTION
main is the property npm uses to know what to require. It was requiring the Gruntfile instead of the compiled source. :beers:
