### PR TITLE
fix the isNumeric and arrayEqual assert

### DIFF
--- a/src/equal.js
+++ b/src/equal.js
@@ -103,16 +103,25 @@ Snap.plugin(function (Snap, Element, Paper, glob) {
         }
         return out;
     }
+    function isNumeric(obj) {
+        return isFinite(parseFloat(obj));
+    }
+    function arrayEqual(arr1, arr2) {
+        if(!Snap.is(arr1, "array") || !Snap.is(arr2, "array")){
+            return false;
+        }
+        return arr1.sort().toString() == arr2.sort().toString();
+    }
     Element.prototype.equal = function (name, b) {
         return eve("snap.util.equal", this, name, b).firstDefined();
     };
     eve.on("snap.util.equal", function (name, b) {
         var A, B, a = Str(this.attr(name) || ""),
             el = this;
-        if (a == +a && b == +b) {
+        if (isNumeric(a) && isNumeric(b)) {
             return {
-                from: +a,
-                to: +b,
+                from: parseFloat(a),
+                to: parseFloat(b),
                 f: getNumber
             };
         }
@@ -155,7 +164,7 @@ Snap.plugin(function (Snap, Element, Paper, glob) {
         }
         aUnit = a.match(reUnit);
         var bUnit = Str(b).match(reUnit);
-        if (aUnit && aUnit == bUnit) {
+        if (aUnit && arrayEqual(aUnit, bUnit)) {
             return {
                 from: parseFloat(a),
                 to: parseFloat(b),


### PR DESCRIPTION
The isNumeric parseFloat and arrayEqual logic in equal.js result in a bug that if an element's strokeWidth has been set, then animation on it won't work. Because +"0px" become NaN. 

And arrayEqual using == also won't work(match() returns an array，["px"] == ["px"] will result in false)

PS: 1st time pull request... forgive a newbee, just want to keep on with the new version.