### PR TITLE
Fix regression from v0.2.0 when animating transforms

### DIFF
--- a/src/element.js
+++ b/src/element.js
@@ -171,6 +171,7 @@ Snap.plugin(function (Snap, Element, Paper, glob, Fragment) {
         }
         if (tstr instanceof Snap.Matrix) {
             this.matrix = tstr;
+            this._.transform = tstr.toTransformString();
         } else {
             extractTransform(this, tstr);
         }


### PR DESCRIPTION
I ran across an issue with the current version of Snap.svg that worked correctly in a previous version (`v0.2.0`). When attempting to animate a transform (in my case, a simple translate), the element's current transform appears to "reset," instead of animating into the target transform.

Compare the [v0.2.0](http://jsfiddle.net/7o3y7kf9/4/) with [the current version](http://jsfiddle.net/7o3y7kf9/3/).

Note that the issue does not occur when using a transform string - only when using a `Snap.Matrix` instance. 

(From what I can tell, when v0.2.0 would receive a matrix as an argument, it would just convert it to a transform string and then call `extractTransform`, which did a few things - one of which was setting `el._.transform`. The new code tries to directly assign the matrix instead of re-parsing it, but it wasn't assigning to `this._.transform`)
