### PR TITLE
Update svg.js

### DIFF
--- a/src/svg.js
+++ b/src/svg.js
@@ -2287,7 +2287,6 @@ Snap.parse = function (svg) {
             }
         }
     }
-    div.innerHTML = E;
     return new Fragment(f);
 };
 function Fragment(frag) {


### PR DESCRIPTION
Remove div.innerHTML = E becaue this causes problems in IE11. Clearing the div in this way causes the extracted svg to be cleared out of all child nodes.