### PR TITLE
Fixed equal.js aggressive numeric type capture regression

### DIFF
--- a/src/equal.js
+++ b/src/equal.js
@@ -121,13 +121,6 @@ Snap.plugin(function (Snap, Element, Paper, glob) {
     eve.on("snap.util.equal", function (name, b) {
         var A, B, a = Str(this.attr(name) || ""),
             el = this;
-        if (isNumeric(a) && isNumeric(b)) {
-            return {
-                from: parseFloat(a),
-                to: parseFloat(b),
-                f: getNumber
-            };
-        }
         if (names[name] == "colour") {
             A = Snap.color(a);
             B = Snap.color(b);
@@ -172,6 +165,13 @@ Snap.plugin(function (Snap, Element, Paper, glob) {
                 from: A,
                 to: B,
                 f: function (val) { return val; }
+            };
+        }
+        if (isNumeric(a) && isNumeric(b)) {
+            return {
+                from: parseFloat(a),
+                to: parseFloat(b),
+                f: getNumber
             };
         }
         var aUnit = a.match(reUnit),


### PR DESCRIPTION
Fixes #373

The numeric condition in equal.js was changed in 69441e9 from PR #282 

The new condition is able to capture more types of values, including the "points" attribute, whose values come in the form of a string of comma delimited numbers. This is because the `isNumeric` function relies on `parseFloat`, and `parseFloat('1, 2, 3, 4')` will use the first number in the string and convert it into a number type.

I have not changed the `isNumeric` function because I cannot reproduce the issue PR #282 claims to fix, and I do not know all of the form of values it is supposed to capture. However it can be safely assumed that all of the named conditions should take priority because they have greater specificity, so i have moved the numeric condition underneath these.