### PR TITLE
chore(package.json): Use production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "./dist/snap.svg-min.js",
     "repository": {
         "type": "git",
-        "url": "git@github.com:adobe-webplatform/Snap.svg.git"
+        "url": "git@github.com:davismj/Snap.svg.git"
     },
     "author": "Dmitry Baranovskiy",
     "license": "Apache License v2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "snapsvg",
     "version": "0.4.1",
     "description": "JavaScript Vector Library",
-    "main": "./dist/snap.svg.js",
+    "main": "./dist/snap.svg-min.js",
     "repository": {
         "type": "git",
         "url": "git@github.com:adobe-webplatform/Snap.svg.git"


### PR DESCRIPTION
Right now, the `package.json` uses the dev build as the `main` entry point. This commit points to the production build.
