### PR TITLE
Make text selectable and selections visible in the docs

### DIFF
--- a/doc/css/prism.css
+++ b/doc/css/prism.css
@@ -113,13 +113,6 @@ pre[data-line] {
 	color: hsl(33, 33%, 52%); /* #AC885B */
 }
 
-/* Text Selection colour */
-::selection {
-	background: hsla(0,0%,93%,0.15); /* #EDEDED */
-}
-::-moz-selection {
-	background: hsla(0,0%,93%,0.15); /* #EDEDED */
-}
 
 /* Make the tokens sit above the line highlight so the colours don't look faded. */
 .token {

--- a/doc/css/topcoat-desktop-light.css
+++ b/doc/css/topcoat-desktop-light.css
@@ -1493,10 +1493,6 @@ input[type="checkbox"]:focus + .topcoat-checkbox__checkmark:before {
   background: transparent;
   border: none;
   cursor: default;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
 }


### PR DESCRIPTION
This change removes the virtually invisible custom selection style so we can see what we're selecting, and allows user selection on the parameter tables.

Being able to copy+paste from the docs is crucial when getting started, and some find it easier to read by highlighting text.
