### PR TITLE
Fix typo in reference docs

### DIFF
--- a/doc/reference.html
+++ b/doc/reference.html
@@ -9653,7 +9653,7 @@ the class’s presence or the value of the <code>flag</code> argument.
                                               <span class="dr-description">start <em>master</em> number (start time in general case)</span></li>
                                           <li class="topcoat-list__item"><span class="dr-param">B</span>
                                               <span class="dr-type"><em class="dr-type-number">number</em> </span>
-                                              <span class="dr-description">end <em>master</em> number (end time in gereal case)</span></li>
+                                              <span class="dr-description">end <em>master</em> number (end time in general case)</span></li>
                                           <li class="topcoat-list__item"><span class="dr-param">get</span>
                                               <span class="dr-type"><em class="dr-type-function">function</em> </span>
                                               <span class="dr-description">getter of <em>master</em> number (see <a href="#mina.time" class="dr-link">mina.time</a>)</span></li>


### PR DESCRIPTION
Fix misspelled word in documentation reference page.