### PR TITLE
Return XMLHttpRequest object from Snap.load

### DIFF
--- a/src/svg.js
+++ b/src/svg.js
@@ -1774,9 +1774,10 @@ Snap.ajax = function (url, postData, callback, scope){
  - url (string) URL
  - callback (function) callback
  - scope (object) #optional scope of callback
+ = (XMLHttpRequest) the XMLHttpRequest object, just in case
 \*/
 Snap.load = function (url, callback, scope) {
-    Snap.ajax(url, function (req) {
+    return Snap.ajax(url, function (req) {
         var f = Snap.parse(req.responseText);
         scope ? callback.call(scope, f) : callback(f);
     });


### PR DESCRIPTION
Return XMLHttpRequest object from Snap.load just in case there is a need for it.