### PR TITLE
Adds Pointer Event listeners

### DIFF
--- a/src/mouse.js
+++ b/src/mouse.js
@@ -25,6 +25,13 @@ Snap.plugin(function (Snap, Element, Paper, glob) {
         mousemove: "touchmove",
         mouseup: "touchend"
     },
+    pointerMap = {
+        mouseup: "pointerup",
+        mousedown: "pointerdown",
+        mousemove: "pointermove",
+        mouseout: "pointerout",
+        mouseover: "pointerover"
+    },
     getScroll = function (xy, el) {
         var name = xy == "y" ? "scrollTop" : "scrollLeft",
             doc = el && el.node ? el.node.ownerDocument : glob.doc;
@@ -62,10 +69,15 @@ Snap.plugin(function (Snap, Element, Paper, glob) {
                 var x = e.clientX + scrollX,
                     y = e.clientY + scrollY;
                 return fn.call(element, e, x, y);
-            };
+            },
+            pointerName = pointerMap[type];
 
         if (type !== realName) {
             obj.addEventListener(type, f, false);
+        }
+
+        if (pointerName) {
+          obj.addEventListener(pointerName, f, false);
         }
 
         obj.addEventListener(realName, f, false);
@@ -73,6 +85,10 @@ Snap.plugin(function (Snap, Element, Paper, glob) {
         return function () {
             if (type !== realName) {
                 obj.removeEventListener(type, f, false);
+            }
+
+            if (pointerName) {
+              obj.removeEventListener(pointerName, f, false);
             }
 
             obj.removeEventListener(realName, f, false);


### PR DESCRIPTION
Mouse and touch events are swallowed, in pointer event supporting browsers, by pointer event handlers unless this library attaches pointerevent handlers of its own.

This commit adds those copies of the regular mouse event handlers.

Note that pointerevents are ignored in browsers that do not support them (as of this writing, only the most recent version of chrome supports pointer events)