### PR TITLE
Fix clipPath coercion when used multiple times

### DIFF
--- a/src/attr.js
+++ b/src/attr.js
@@ -53,9 +53,20 @@ Snap.plugin(function (Snap, Element, Paper, glob, Fragment) {
     }(function (value) {
         if (value instanceof Element || value instanceof Fragment) {
             eve.stop();
-            if (value.type == "clipPath") {
-                var clip = value;
-            } else {
+            var clip,
+                node = value.node;
+            while (node) {
+                if (node.nodeName === "clipPath") {
+                    clip = new Element(node);
+                    break;
+                }
+                if (node.nodeName === "svg") {
+                    clip = undefined;
+                    break;
+                }
+                node = node.parentNode;
+            }
+            if (!clip) {
                 clip = make("clipPath", getSomeDefs(this));
                 clip.node.appendChild(value.node);
                 !clip.node.id && $(clip.node, {


### PR DESCRIPTION
Check parent nodes before coercing elements into clipPaths to prevent
the same element being coerced multiple times.

Fixes #471