### PR TITLE
Fix bug "Failed to construct 'URL': Please use the 'new' operator" 

### DIFF
--- a/src/attr.js
+++ b/src/attr.js
@@ -64,7 +64,7 @@ Snap.plugin(function (Snap, Element, Paper, glob, Fragment) {
                 id: mask.id
             });
             $(this.node, {
-                mask: URL(mask.id)
+                mask: Snap.url(mask.id)
             });
         }
     });
@@ -85,7 +85,7 @@ Snap.plugin(function (Snap, Element, Paper, glob, Fragment) {
                 });
             }
             $(this.node, {
-                "clip-path": URL(clip.node.id || clip.id)
+                "clip-path": Snap.url(clip.node.id || clip.id)
             });
         }
     }));
@@ -108,7 +108,7 @@ Snap.plugin(function (Snap, Element, Paper, glob, Fragment) {
                             id: value.id
                         });
                     }
-                    var fill = URL(value.node.id);
+                    var fill = Snap.url(value.node.id);
                 } else {
                     fill = value.attr(name);
                 }
@@ -122,7 +122,7 @@ Snap.plugin(function (Snap, Element, Paper, glob, Fragment) {
                                 id: grad.id
                             });
                         }
-                        fill = URL(grad.node.id);
+                        fill = Snap.url(grad.node.id);
                     } else {
                         fill = value;
                     }
@@ -362,7 +362,7 @@ Snap.plugin(function (Snap, Element, Paper, glob, Fragment) {
                     if (!id) {
                         $(value.node, {id: value.id});
                     }
-                    this.node.style[name] = URL(id);
+                    this.node.style[name] = Snap.url(id);
                     return;
                 }
             };

--- a/src/element.js
+++ b/src/element.js
@@ -490,7 +490,7 @@ Snap.plugin(function (Snap, Element, Paper, glob, Fragment) {
             if (val) {
                 uses[val] = (uses[val] || []).concat(function (id) {
                     var attr = {};
-                    attr[name] = URL(id);
+                    attr[name] = Snap.url(id);
                     $(it.node, attr);
                 });
             }


### PR DESCRIPTION
Error is : Constructor URL requires 'new'.

See the last comments of this thread  for more information about the error : https://github.com/adobe-webplatform/Snap.svg/issues/390

thx
YLerjen