### PR TITLE
Add setStops to radialGradient

### DIFF
--- a/src/paper.js
+++ b/src/paper.js
@@ -667,6 +667,7 @@ Snap.plugin(function (Snap, Element, Paper, glob, Fragment) {
             el.stops = Gstops;
             el.addStop = GaddStop;
             el.getBBox = GgetBBox;
+            el.setStops = GsetStops;
             if (cx != null) {
                 $(el.node, {
                     cx: cx,


### PR DESCRIPTION
The setStops method is missing from radialGradient elements. It's present on linearGradient elements.

This change fixes http://stackoverflow.com/questions/43264760/snap-svg-setstops-causing-error