### PR TITLE
add dependencies and dev dependencies badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ import Snap from 'snapsvg';
 
 ### Build
 [![Build Status](https://travis-ci.org/adobe-webplatform/Snap.svg.svg?branch=dev)](https://travis-ci.org/adobe-webplatform/Snap.svg)
+[![Dependency Status](https://david-dm.org/adobe-webplatform/Snap.svg.svg)](https://david-dm.org/adobe-webplatform/Snap.svg)
+[![devDependency Status](https://david-dm.org/adobe-webplatform/Snap.svg/dev-status.svg)](https://david-dm.org/adobe-webplatform/Snap.svg#info=devDependencies)
 
 Snap.svg uses [Grunt](http://gruntjs.com/) to build.
 


### PR DESCRIPTION
the badge use https://david-dm.org, i also notice that the build badge is pointed to dev `?branch=dev` .
Is that really desired? since recent pr is merge to / pointed to master.
With a couple of deprecation warning [here](https://travis-ci.org/adobe-webplatform/Snap.svg/builds/282220968#L444), i would suggest to upgrade some module, figured below:
![deprecated snap dep 0 5 1](https://user-images.githubusercontent.com/3001652/31125614-1146e6d0-a873-11e7-8e8e-7f12228ce398.PNG)

If my suggestion is accepted, i will make a PR, but it need other PR on those module accepted first.
