### PR TITLE
Doc remove duplicate build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[Snap.svg](http://snapsvg.io) · [![Build Status](https://travis-ci.org/adobe-webplatform/Snap.svg.svg?branch=dev)](https://travis-ci.org/adobe-webplatform/Snap.svg)  [![CDNJS](https://img.shields.io/cdnjs/v/snap.svg.svg)](https://cdnjs.com/libraries/snap.svg/) [![GitHub Tag](https://img.shields.io/github/tag/adobe-webplatform/snap.svg.svg)](https://github.com/adobe-webplatform/Snap.svg/releases) [![License](https://img.shields.io/npm/l/snapsvg.svg)](https://github.com/adobe-webplatform/Snap.svg/blob/master/LICENSE)
+[Snap.svg](http://snapsvg.io) · [![CDNJS](https://img.shields.io/cdnjs/v/snap.svg.svg)](https://cdnjs.com/libraries/snap.svg/) [![GitHub Tag](https://img.shields.io/github/tag/adobe-webplatform/snap.svg.svg)](https://github.com/adobe-webplatform/Snap.svg/releases) [![License](https://img.shields.io/npm/l/snapsvg.svg)](https://github.com/adobe-webplatform/Snap.svg/blob/master/LICENSE)
 ======
 
 A JavaScript SVG library for the modern web. Learn more at [snapsvg.io](http://snapsvg.io).


### PR DESCRIPTION
i just realize that the badge is duplicate, I just remove the top badge, and leave the bottom one. Because the bottom have contextual relation with dependency and dev dependency. Have a nice day :smile: