### PR TITLE
createTouch - Deprecated

### DIFF
--- a/src/mouse.js
+++ b/src/mouse.js
@@ -14,7 +14,7 @@
 Snap.plugin(function (Snap, Element, Paper, glob) {
     var elproto = Element.prototype,
     has = "hasOwnProperty",
-    supportsTouch = "createTouch" in glob.doc,
+    supportsTouch = (('ontouchstart' in window) || window.TouchEvent || window.DocumentTouch && document instanceof DocumentTouch),
     events = [
         "click", "dblclick", "mousedown", "mousemove", "mouseout",
         "mouseover", "mouseup", "touchstart", "touchmove", "touchend",


### PR DESCRIPTION
createTouch has been deprecated for a while now.

This fix uses the same technique used by Modernizr - https://github.com/Modernizr/Modernizr/blob/377a6303b3b6d400979eeae351e1dcf43972eef4/feature-detects/touchevents.js#L40