### PR TITLE
Fixing anchor on Paper Gradient link

### DIFF
--- a/doc/reference.html
+++ b/doc/reference.html
@@ -6530,8 +6530,8 @@ var p2 = paper.polyline(10, 10, 100, 100);</code></pre></section>
                             <div class="dr-method">
                                 <p>Only for gradients! Updates stops of the gradient
                                     based on passed gradient descriptor. See
-                                    <a href="#Ppaer.gradient"
-                                    class="dr-link">Ppaer.gradient</a>
+                                    <a href="#Paper.gradient"
+                                    class="dr-link">Paper.gradient</a>
                                 </p>
                                 <div class="params">
                                     <h3 class="params">Parameters</h3>


### PR DESCRIPTION
The anchor link provided in the doc had a typo