### PR TITLE
Fix Snap.atan2 to use 2 arguments

### DIFF
--- a/src/svg.js
+++ b/src/svg.js
@@ -379,11 +379,12 @@ Snap.atan = function (num) {
  [ method ]
  **
  * Equivalent to `Math.atan2()` only works with degrees, not radians.
- - num (number) value
+ - x (number) value
+ - y (number) value
  = (number) atan2 in degrees
 \*/
-Snap.atan2 = function (num) {
-    return Snap.deg(math.atan2(num));
+Snap.atan2 = function (x, y) {
+    return Snap.deg(math.atan2(x, y));
 };
 /*\
  * Snap.angle


### PR DESCRIPTION
`Snap.atan2` wraps `Math.atan2`, but only takes and passes a single argument, even though `Math.atan2` takes two.

Fixes #507 